### PR TITLE
Fixed typo in the Designated Funds label

### DIFF
--- a/seamless-donations-form.php
+++ b/seamless-donations-form.php
@@ -285,7 +285,7 @@ function seamless_donations_get_donation_section() {
                 'id'     => 'dgx-donate-designated',
                 'reveal' => 'specific-fund',
                 'prompt' => esc_html__(
-                    "I would like to this donation to go to a specific fund", 'seamless-donations'),
+                    "I would like this donation to go to a specific fund", 'seamless-donations'),
                 'before' => '<p>',
                 'after'  => '</p>',
             );


### PR DESCRIPTION
Ticket: https://zatzlabs.com/ticket/typo-in-designated-funds/

@davidgewirtz: Sorry, I didn't realize this was open-source until after I opened the ticket, or I would've just done the pull request instead.

I noticed that a lot of the translations seem to have this line: `msgid "I would like to designate this donation to a specific fund"`. I'm not sure how the internationalization system works; please let me know if I need to adjust this pull request to match that msgid exactly.